### PR TITLE
feat: Support direct image sharing via Web Share Target API

### DIFF
--- a/src/pages/Editor.jsx
+++ b/src/pages/Editor.jsx
@@ -1,4 +1,4 @@
-import { useParams, useNavigate } from 'react-router-dom';
+import { useParams, useNavigate, useLocation } from 'react-router-dom';
 import { useState, useEffect, useRef } from 'react';
 import { storageService } from '../services/storage';
 import { ocrService } from '../services/ocr';
@@ -17,6 +17,7 @@ import ImageCropper from '../components/ImageCropper';
 function Editor() {
   const { id } = useParams();
   const navigate = useNavigate();
+  const location = useLocation();
 
   // State
   const [formData, setFormData] = useState({
@@ -105,9 +106,23 @@ function Editor() {
                 setFormData(prev => ({ ...prev, ...updates }));
             }
         }
+
+        // Handle Web Share Target
+        if (id === 'new' && location.search.includes('shared=true')) {
+            const sharedImage = await storageService.getSharedImage();
+            if (sharedImage) {
+                await storageService.clearSharedImage();
+                // Pass it to processFile immediately
+                // Wait for the next tick so the component fully mounts before updating state heavily
+                setTimeout(() => {
+                    processFile(sharedImage, sharedImage.type === 'application/pdf');
+                }, 100);
+            }
+        }
     };
     loadData();
-  }, [id]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [id, location.search]);
 
   const handleChange = (e) => {
     const { name, value } = e.target;

--- a/src/services/storage.js
+++ b/src/services/storage.js
@@ -52,6 +52,15 @@ export const storageService = {
     return data || { categories: [], accounts: [], payees: [] };
   },
 
+  getSharedImage: async () => {
+    const file = await (await dbPromise).get(STORE_CACHE, 'shared_image');
+    return file;
+  },
+
+  clearSharedImage: async () => {
+    await (await dbPromise).delete(STORE_CACHE, 'shared_image');
+  },
+
   clearAll: async () => {
       const db = await dbPromise;
       await db.clear(STORE_TRANSACTIONS);

--- a/src/sw.js
+++ b/src/sw.js
@@ -1,0 +1,55 @@
+import { precacheAndRoute } from 'workbox-precaching';
+
+// Precache assets injected by vite-plugin-pwa
+precacheAndRoute(self.__WB_MANIFEST || []);
+
+// Listen for fetch events
+self.addEventListener('fetch', (event) => {
+  const url = new URL(event.request.url);
+
+  // Intercept the Web Share Target POST request
+  if (event.request.method === 'POST' && url.pathname.endsWith('/share-target')) {
+    event.respondWith((async () => {
+      try {
+        const formData = await event.request.formData();
+        const file = formData.get('image');
+
+        if (file) {
+          // Open IndexedDB to save the shared file
+          const dbName = 'hb_go_db';
+          const storeName = 'cache';
+
+          const request = indexedDB.open(dbName);
+
+          await new Promise((resolve, reject) => {
+            request.onsuccess = (e) => {
+              const db = e.target.result;
+              const transaction = db.transaction([storeName], 'readwrite');
+              const store = transaction.objectStore(storeName);
+
+              const putRequest = store.put(file, 'shared_image');
+
+              putRequest.onsuccess = () => resolve();
+              putRequest.onerror = () => reject(putRequest.error);
+            };
+            request.onerror = () => reject(request.error);
+          });
+        }
+
+        // Redirect back to the app with a query param to trigger the Editor
+        return Response.redirect('/hb-go/#/editor/new?shared=true', 303);
+      } catch (error) {
+        console.error('Error handling share target POST:', error);
+        return Response.redirect('/hb-go/', 303);
+      }
+    })());
+  }
+});
+
+self.addEventListener('install', () => {
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(self.clients.claim());
+});

--- a/vite.config.js
+++ b/vite.config.js
@@ -14,6 +14,9 @@ export default defineConfig({
     VitePWA({
       registerType: 'autoUpdate',
       includeAssets: ['favicon.png', 'robots.txt', 'icons/*.png'],
+      strategies: 'injectManifest',
+      srcDir: 'src',
+      filename: 'sw.js',
       manifest: {
         name: 'HB Go',
         short_name: 'HB Go',
@@ -33,7 +36,23 @@ export default defineConfig({
             sizes: '512x512',
             type: 'image/png'
           }
-        ]
+        ],
+        share_target: {
+          action: '/hb-go/share-target',
+          method: 'POST',
+          enctype: 'multipart/form-data',
+          params: {
+            title: 'title',
+            text: 'text',
+            url: 'url',
+            files: [
+              {
+                name: 'image',
+                accept: ['image/*', 'application/pdf']
+              }
+            ]
+          }
+        }
       }
     })
   ],


### PR DESCRIPTION
This PR implements the Web Share Target API, allowing users to share an image directly from their OS (e.g., photo gallery or camera roll) to the HB Go app. 

When an image is shared:
1. The service worker intercepts the POST request.
2. The image is saved to IndexedDB (`cache` store).
3. The user is redirected to the Editor (`/#/editor/new?shared=true`).
4. The Editor detects the shared image, skips the cropping step, and immediately begins processing it with OCR/AI.

---
*PR created automatically by Jules for task [3544291504441163318](https://jules.google.com/task/3544291504441163318) started by @lawrancekoh*