### PR TITLE
Fix fallback to system OCR for shared images

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "eslint-plugin-react-hooks": "^7.0.1",
         "eslint-plugin-react-refresh": "^0.4.24",
         "globals": "^16.5.0",
-        "jsdom": "^27.2.0",
+        "jsdom": "^27.4.0",
         "postcss": "^8.5.6",
         "tailwindcss": "^3.4.17",
         "vite": "^7.2.4",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.4.24",
     "globals": "^16.5.0",
-    "jsdom": "^27.2.0",
+    "jsdom": "^27.4.0",
     "postcss": "^8.5.6",
     "tailwindcss": "^3.4.17",
     "vite": "^7.2.4",

--- a/src/pages/Editor.jsx
+++ b/src/pages/Editor.jsx
@@ -129,10 +129,10 @@ function Editor() {
     setFormData(prev => ({ ...prev, [name]: value }));
   };
 
-  const performAiScan = async (fileToScan) => {
+  const performAiScan = async (fileToScan, currentAiConfig = aiConfig) => {
       setOcrStatus('AI Analyzing...');
       try {
-           const result = await llmService.scanReceiptWithAI(fileToScan, aiConfig);
+           const result = await llmService.scanReceiptWithAI(fileToScan, currentAiConfig);
 
           // Smart match payee
           let bestPayee = result.merchant || '';
@@ -294,9 +294,13 @@ function Editor() {
 
           setPreviewUrl(previewData);
 
-          // Check if AI should be used
-          if (aiConfig && aiConfig.apiKey) {
-              await performAiScan(fileToProcess);
+          // Check if AI should be used (handling stale closures on mount)
+          const storedAiConfigStr = localStorage.getItem('hb_ai_config');
+          const currentAiConfig = aiConfig || (storedAiConfigStr ? JSON.parse(storedAiConfigStr) : null);
+
+          if (currentAiConfig && currentAiConfig.apiKey) {
+              // Pass the current config to performAiScan explicitly
+              await performAiScan(fileToProcess, currentAiConfig);
           } else {
               setOcrStatus('Reading text...');
               const settings = await storageService.getSettings();


### PR DESCRIPTION
The application was incorrectly falling back to System OCR instead of the configured Cloud AI OCR when processing images shared directly from the OS to the PWA.

This occurred because the `processFile` method, invoked via a `setTimeout` within an initial `useEffect` when `shared=true` is present, referenced the initial `aiConfig` state (`null`) rather than waiting for the state to be updated from `localStorage`.

The fix pulls the `hb_ai_config` directly from `localStorage` within `processFile` if the state is missing, ensuring the shared image correctly uses the configured Cloud AI scanner.

---
*PR created automatically by Jules for task [4660627667146326218](https://jules.google.com/task/4660627667146326218) started by @lawrancekoh*